### PR TITLE
Move logout and reset buttons from sidebar to top bar

### DIFF
--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -2,13 +2,44 @@
 
 import { RefreshButton } from './RefreshButton'
 import { ThemeToggle } from './theme-toggle'
+import { Button } from '@/components/ui/button'
+import { LogOut, RotateCcw } from 'lucide-react'
+import { useSession, signOut } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 
 export function TopBar() {
+  const { data: session } = useSession()
+  const router = useRouter()
+
+  const handleResetProfile = () => {
+    router.push('/profile')
+  }
+
   return (
     <div className="flex w-full items-center justify-between px-16 md:px-17 pt-6 pb-0 mb-0">
       <div className="text-2xl md:text-3xl font-bold text-primary">PEC.UP</div>
       <div className="flex gap-2">
         <RefreshButton />
+        {session && (
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleResetProfile}
+            >
+              <RotateCcw className="h-4 w-4" />
+              Reset Year & Branch
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => signOut()}
+            >
+              <LogOut className="h-4 w-4" />
+              Logout
+            </Button>
+          </>
+        )}
         <ThemeToggle />
       </div>
     </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -111,26 +111,6 @@ export function Sidebar() {
             </nav>
           </ScrollArea>
 
-          {session && (
-            <div className="p-4 border-t space-y-2">
-              <Button
-                variant="ghost"
-                className="w-full flex justify-start gap-2 text-sm"
-                onClick={handleResetProfile}
-              >
-                <RotateCcw className="h-4 w-4" />
-                Reset Year & Branch
-              </Button>
-              <Button
-                variant="ghost"
-                className="w-full flex justify-start gap-2 text-sm"
-                onClick={() => signOut()}
-              >
-                <LogOut className="h-4 w-4" />
-                Logout
-              </Button>
-            </div>
-          )}
 
           <div className="p-4 text-xs text-muted-foreground">
             © 2025 Yeswanth Madasu


### PR DESCRIPTION
This PR moves the logout and reset year & branch buttons from the sidebar to the top bar for better accessibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logout and Reset Year & Branch buttons now available in the top bar when logged in.

* **Refactor**
  * Session-dependent UI removed from sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->